### PR TITLE
TheScore Dev Changes

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncService.java
@@ -124,7 +124,7 @@ public abstract class HoodieAsyncService implements Serializable {
           executor.shutdown();
           try {
             // Wait for some max time after requesting shutdown
-            executor.awaitTermination(24, TimeUnit.HOURS);
+            executor.awaitTermination(10, TimeUnit.SECONDS);
           } catch (InterruptedException ie) {
             LOG.error("Interrupted while waiting for shutdown", ie);
           }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/TimestampBasedAvroKeyGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/keygen/TimestampBasedAvroKeyGenerator.java
@@ -41,6 +41,7 @@ import java.time.LocalDate;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -49,7 +50,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 public class TimestampBasedAvroKeyGenerator extends SimpleAvroKeyGenerator {
   public enum TimestampType implements Serializable {
-    UNIX_TIMESTAMP, DATE_STRING, MIXED, EPOCHMILLISECONDS, SCALAR
+    UNIX_TIMESTAMP, DATE_STRING, MIXED, EPOCHMILLISECONDS, EPOCHMICROSECONDS, SCALAR
   }
 
   private final TimeUnit timeUnit;
@@ -87,6 +88,9 @@ public class TimestampBasedAvroKeyGenerator extends SimpleAvroKeyGenerator {
     switch (this.timestampType) {
       case EPOCHMILLISECONDS:
         timeUnit = MILLISECONDS;
+        break;
+      case EPOCHMICROSECONDS:
+        timeUnit = MICROSECONDS;
         break;
       case UNIX_TIMESTAMP:
         timeUnit = SECONDS;

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/SparkKeyGenUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/util/SparkKeyGenUtils.scala
@@ -41,16 +41,23 @@ object SparkKeyGenUtils {
    * @param keyGen key generator
    * @return partition columns
    */
-  def getPartitionColumns(keyGen: KeyGenerator, typedProperties: TypedProperties): String = {
+  def getPartitionColumns(keyGen: KeyGenerator, typedProperties: TypedProperties, forConfFile: Boolean=false): String = {
     keyGen match {
       // For CustomKeyGenerator and CustomAvroKeyGenerator, the partition path filed format
       // is: "field_name: field_type", we extract the field_name from the partition path field.
       case c: BaseKeyGenerator
         if c.isInstanceOf[CustomKeyGenerator] || c.isInstanceOf[CustomAvroKeyGenerator] =>
-        c.getPartitionPathFields.asScala.map(pathField =>
-          pathField.split(CustomAvroKeyGenerator.SPLIT_REGEX)
-            .headOption.getOrElse(s"Illegal partition path field format: '$pathField' for ${c.getClass.getSimpleName}"))
-          .mkString(",")
+            if (forConfFile) {
+                // don't split the path field by ":" for the hoodie.properties file (so future runs are compatible)
+                c.getPartitionPathFields.asScala.mkString(",")
+            } else {
+                // when normally getting the partitionpath, extract the field_name only
+                c.getPartitionPathFields.asScala.map(pathField =>
+                  pathField.split(CustomAvroKeyGenerator.SPLIT_REGEX)
+                    .headOption.getOrElse(s"Illegal partition path field format: '$pathField' for ${c.getClass.getSimpleName}"))
+                  .mkString(",")
+            }
+
 
       case b: BaseKeyGenerator => b.getPartitionPathFields.asScala.mkString(",")
       case _ => typedProperties.getString(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key())

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -363,7 +363,7 @@ public class DeltaSync implements Serializable, Closeable {
   private void initializeEmptyTable() throws IOException {
     this.commitTimelineOpt = Option.empty();
     this.allCommitsTimelineOpt = Option.empty();
-    String partitionColumns = SparkKeyGenUtils.getPartitionColumns(keyGenerator, props);
+    String partitionColumns = SparkKeyGenUtils.getPartitionColumns(keyGenerator, props, true);
     HoodieTableMetaClient.withPropertyBuilder()
         .setTableType(cfg.tableType)
         .setTableName(cfg.targetTableName)
@@ -460,7 +460,7 @@ public class DeltaSync implements Serializable, Closeable {
       resumeCheckpointStr = getCheckpointToResume(commitTimelineOpt);
     } else {
       // initialize the table for the first time.
-      String partitionColumns = SparkKeyGenUtils.getPartitionColumns(keyGenerator, props);
+      String partitionColumns = SparkKeyGenUtils.getPartitionColumns(keyGenerator, props, true);
       HoodieTableMetaClient.withPropertyBuilder()
           .setTableType(cfg.tableType)
           .setTableName(cfg.targetTableName)
@@ -1181,7 +1181,7 @@ public class DeltaSync implements Serializable, Closeable {
    * @return Set of partition columns.
    */
   private Set<String> getPartitionColumns(KeyGenerator keyGenerator, TypedProperties props) {
-    String partitionColumns = SparkKeyGenUtils.getPartitionColumns(keyGenerator, props);
+    String partitionColumns = SparkKeyGenUtils.getPartitionColumns(keyGenerator, props, false);
     return Arrays.stream(partitionColumns.split(",")).collect(Collectors.toSet());
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -744,6 +744,7 @@ public class HoodieDeltaStreamer implements Serializable {
                 LOG.warn("Closing and shutting down ingestion service");
                 error = true;
                 onIngestionCompletes(false);
+                shutdownAsyncServices(error);
                 shutdown(true);
               } else {
                 sleepBeforeNextIngestion(start);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
@@ -115,7 +115,8 @@ public class HoodieMultiTableDeltaStreamer {
     for (String table : tablesToBeIngested) {
       String[] tableWithDatabase = table.split("\\.");
       String database = tableWithDatabase.length > 1 ? tableWithDatabase[0] : "default";
-      String currentTable = tableWithDatabase.length > 1 ? tableWithDatabase[1] : table;
+      String currentTable = tableWithDatabase.length > 1 ? (tableWithDatabase.length == 3 ? tableWithDatabase[1] + "." + tableWithDatabase[2] : tableWithDatabase[1]) : table;
+      logger.info("Current table is " + currentTable);
       String configProp = HoodieDeltaStreamerConfig.INGESTION_PREFIX + database + Constants.DELIMITER + currentTable + Constants.INGESTION_CONFIG_SUFFIX;
       String configFilePath = properties.getString(configProp, Helpers.getDefaultConfigFilePath(configFolder, database, currentTable));
       checkIfTableConfigFileExists(configFolder, fs, configFilePath);
@@ -421,7 +422,11 @@ public class HoodieMultiTableDeltaStreamer {
   private static String resetTarget(Config configuration, String database, String tableName) {
     String basePathPrefix = configuration.basePathPrefix;
     basePathPrefix = basePathPrefix.charAt(basePathPrefix.length() - 1) == '/' ? basePathPrefix.substring(0, basePathPrefix.length() - 1) : basePathPrefix;
-    String targetBasePath = basePathPrefix + Constants.FILE_DELIMITER + database + Constants.FILE_DELIMITER + tableName;
+    String basePathWithDatabase = basePathPrefix + Constants.FILE_DELIMITER + database;
+    String[] tableNameWithSchema = tableName.split("\\.");
+    String targetBasePath = tableNameWithSchema.length > 1 ? basePathWithDatabase + Constants.FILE_DELIMITER
+        + tableNameWithSchema[0] + Constants.FILE_DELIMITER + tableNameWithSchema[1]
+        : basePathWithDatabase + Constants.FILE_DELIMITER + tableName;
     configuration.targetTableName = database + Constants.DELIMITER + tableName;
     return targetBasePath;
   }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieMultiTableDeltaStreamer.java
@@ -229,6 +229,7 @@ public class HoodieMultiTableDeltaStreamer {
       tableConfig.deltaSyncSchedulingWeight = globalConfig.deltaSyncSchedulingWeight;
       tableConfig.clusterSchedulingWeight = globalConfig.clusterSchedulingWeight;
       tableConfig.clusterSchedulingMinShare = globalConfig.clusterSchedulingMinShare;
+      tableConfig.postWriteTerminationStrategyClass = globalConfig.postWriteTerminationStrategyClass;
       tableConfig.sparkMaster = globalConfig.sparkMaster;
     }
   }
@@ -401,6 +402,9 @@ public class HoodieMultiTableDeltaStreamer {
     @Parameter(names = {"--cluster-scheduling-minshare"}, description = "Minshare for clustering as defined in "
         + "https://spark.apache.org/docs/latest/job-scheduling.html")
     public Integer clusterSchedulingMinShare = 0;
+
+    @Parameter(names = {"--post-write-termination-strategy-class"}, description = "Post writer termination strategy class to gracefully shutdown deltastreamer in continuous mode")
+    public String postWriteTerminationStrategyClass = "";
 
     @Parameter(names = {"--help", "-h"}, help = true)
     public Boolean help = false;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
@@ -152,11 +152,13 @@ public abstract class DebeziumSource extends RowSource {
     if (deserializerClassName.equals(StringDeserializer.class.getName())) {
       kafkaData = AvroConversionUtils.createDataFrame(
           KafkaUtils.<String, String>createRDD(sparkContext, offsetGen.getKafkaParams(), offsetRanges, LocationStrategies.PreferConsistent())
+              .filter(x -> filterForNullValues(x.value()))
               .map(obj -> convertor.fromJson(obj.value()))
               .rdd(), schemaStr, sparkSession);
     } else {
       kafkaData = AvroConversionUtils.createDataFrame(
           KafkaUtils.createRDD(sparkContext, offsetGen.getKafkaParams(), offsetRanges, LocationStrategies.PreferConsistent())
+              .filter(x -> filterForNullValues(x.value()))
               .map(obj -> (GenericRecord) obj.value())
               .rdd(), schemaStr, sparkSession);
     }
@@ -167,6 +169,13 @@ public abstract class DebeziumSource extends RowSource {
     // Some required transformations to ensure debezium data types are converted to spark supported types.
     return convertArrayColumnsToString(convertColumnToNullable(sparkSession,
         convertDateColumns(debeziumDataset, new Schema.Parser().parse(schemaStr))));
+  }
+
+  private static Boolean filterForNullValues(Object value) {
+    if (value == null) {
+      return false;
+    }
+    return true;
   }
 
   /**


### PR DESCRIPTION
### Change Logs

Add EPOCHMICROSECONDS as timestamp format

Enable PostWriteTerminationStrategy for MultiTableDeltaStreamer

Ensure shutdown on Continuous mode for MultiTableDeltaStreamer

Allow partition path field config to be written to hoodie .config file including the :DATATYPE e.g. `hoodie.datasource.write.partitionpath.field=updated_at:TIMESTAMP`

Allow target path parsing for DB table names with 2 `.` in the string - e.g. `db.schema.table` instead of just `db.table`

Filter null/tombstone records from DebeziumSource

### Impact

Deltastreamer is functional for TheScore Data Engineering team

### Risk level (write none, low medium or high below)

Low

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change_

New timestamp type EPOCHMICROSECONDS

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
